### PR TITLE
Ensure backend tests run without OPENAI_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ LOG_FORMAT=plain
 - Use Node.js 18+ for the frontend
 - Recommended: run backend and frontend in separate terminals for development
 - Backend hot-reloads with `--reload`; frontend with Vite HMR
+- **First time setup:** run `./scripts/setup_env.sh` while your workspace still
+  has network access. This installs the Python packages required for the pytest
+  suite as well as the frontend dependencies so tests can run offline later.
 
 ---
 
@@ -158,7 +161,8 @@ cd backend
 
 # (optional) create & activate a virtual-env first
 pip install -r requirements-dev.txt
-# (needs network access, so run this during the online setup phase)
+# (needs network access, so run this during the online setup phase or via
+# `./scripts/setup_env.sh`)
 
 # quick run
 pytest -q

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -1,5 +1,10 @@
 import importlib
+import os
 import pytest
+
+# Ensure settings can be imported even if OPENAI_API_KEY isn't defined by
+# setting a temporary default. The value will be overwritten by tests.
+os.environ.setdefault("OPENAI_API_KEY", "test-api-key")
 from backend.app.core.settings import settings
 
 

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Setup script for local development or CI.
+# Installs backend and frontend dependencies while network access is available.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# ----- Backend -----
+cd "$REPO_ROOT/backend"
+
+# Create virtual environment if missing
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+
+deactivate
+
+# ----- Frontend -----
+cd "$REPO_ROOT/frontend"
+npm install
+
+cd "$REPO_ROOT"
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- no longer require `OPENAI_API_KEY` to run backend tests
- document updated backend test instructions

## Testing
- `npm test --silent` in `frontend`
- `pytest -q` in `backend`
