### PR TITLE
Improve responsive layout for image gallery

### DIFF
--- a/frontend/src/components/GalleryView.tsx
+++ b/frontend/src/components/GalleryView.tsx
@@ -70,7 +70,7 @@ const GalleryView: React.FC = () => {
                 </div>
             )}
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-md gap-y-lg mb-xl">
+            <div className="gallery-grid mb-xl">
                 {images.map(metadata => (
                     <ImageCard key={metadata.id} metadata={metadata} />
                 ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -102,6 +102,26 @@
   padding: 32px;
 }
 
+/* Responsive grid for the gallery */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(1, 1fr);
+  gap: var(--space-md) var(--space-lg);
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 768px) {
+  .gallery-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
 /* Direct class overrides for Tailwind classes that might be causing issues */
 .bg-dark-bg { background-color: #121212 !important; }
 .bg-dark-surface { background-color: #1E1E1E !important; }


### PR DESCRIPTION
## Summary
- make gallery responsive with custom grid classes
- limit gallery to one column on mobile, two on small screens, and three on medium+

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test --silent`
