### PR TITLE
Fix spacing in image forms

### DIFF
--- a/frontend/src/components/ImageGenerationForm.tsx
+++ b/frontend/src/components/ImageGenerationForm.tsx
@@ -72,7 +72,8 @@ function ImageGenerationForm() {
   };
 
   // New styles for form elements
-  const selectBaseClasses = "w-full bg-dark-input text-dark-text-primary border border-dark-border rounded-ui-pill px-4 py-2 focus:outline-none focus:border-dark-accent transition-all duration-200";
+  const selectBaseClasses =
+    "w-full bg-dark-input text-dark-text-primary border border-dark-border rounded-ui-md px-4 py-3 focus:outline-none focus:border-dark-accent transition-all duration-200";
   const radioClasses = "h-4 w-4 text-dark-accent focus:ring-dark-accent border-dark-border bg-dark-input";
 
   // Direct styling for container

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -25,7 +25,7 @@ const TextArea: React.FC<TextAreaProps> = ({
     borderWidth: '1px',
     borderStyle: 'solid',
     borderRadius: '12px',
-    padding: '0.5rem 1rem',
+    padding: '0.75rem 1rem',
     width: fullWidth ? '100%' : undefined,
     resize: 'none' as 'none',
     boxSizing: 'border-box' as 'border-box',
@@ -47,7 +47,7 @@ const TextArea: React.FC<TextAreaProps> = ({
   };
   
   return (
-    <div style={{ marginBottom: '0.5rem', width: fullWidth ? '100%' : undefined, maxWidth: '100%' }}>
+    <div style={{ marginBottom: '1rem', width: fullWidth ? '100%' : undefined, maxWidth: '100%' }}>
       {label && (
         <label 
           htmlFor={textareaId} 

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -24,7 +24,7 @@ const TextInput: React.FC<TextInputProps> = ({
     borderWidth: '1px',
     borderStyle: 'solid',
     borderRadius: '999px',
-    padding: '0.5rem 1rem',
+    padding: '0.75rem 1rem',
     width: fullWidth ? '100%' : undefined
   };
   
@@ -43,7 +43,7 @@ const TextInput: React.FC<TextInputProps> = ({
   };
   
   return (
-    <div style={{ marginBottom: '1.25rem', width: fullWidth ? '100%' : undefined }}>
+    <div style={{ marginBottom: '1rem', width: fullWidth ? '100%' : undefined }}>
       {label && (
         <label 
           htmlFor={inputId} 


### PR DESCRIPTION
## Summary
- tune padding in TextInput and TextArea components
- adjust select styling in image generation form

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test --silent`
