### PR TITLE
fix: resolve backend test async/await issues

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 # dir), so we wrap it inside a fixture.
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture(scope="function")
 async def tmp_storage_dir(tmp_path, monkeypatch):
     """Redirect Settings.storage_dir to a unique temporary directory."""
 
@@ -38,7 +38,7 @@ async def tmp_storage_dir(tmp_path, monkeypatch):
     return tmp_path
 
 
-@pytest_asyncio.fixture()
+@pytest_asyncio.fixture(scope="function")
 async def client(tmp_storage_dir):
     """Return a FastAPI TestClient bound to the application."""
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -8,7 +8,8 @@ os.environ.setdefault("OPENAI_API_KEY", "test-api-key")
 from backend.app.core.settings import settings
 
 
-def test_config_forwards_settings_values(monkeypatch):
+@pytest.mark.asyncio
+async def test_config_forwards_settings_values(monkeypatch):
     # Patch settings values
     test_api_key = "test-api-key"
     test_origins = ["https://test.com", "http://localhost:3000"]

--- a/backend/tests/test_edit_route.py
+++ b/backend/tests/test_edit_route.py
@@ -39,7 +39,8 @@ def mock_openai_edit(mocker):
     )
 
 
-def test_edit_endpoint_success(client):
+@pytest.mark.asyncio
+async def test_edit_endpoint_success(client):
     png = _png_bytes()
 
     resp = client.post(
@@ -54,7 +55,8 @@ def test_edit_endpoint_success(client):
     assert "filename" in payload
 
 
-def test_edit_endpoint_invalid_size(client):
+@pytest.mark.asyncio
+async def test_edit_endpoint_invalid_size(client):
     png = _png_bytes()
 
     r = client.post(

--- a/backend/tests/test_error_paths.py
+++ b/backend/tests/test_error_paths.py
@@ -10,14 +10,16 @@ import pytest
 # ---------------------------------------------------------------------------
 
 
-def test_images_invalid_limit(client):
+@pytest.mark.asyncio
+async def test_images_invalid_limit(client):
     """limit must be >=1 – 0 should raise a 422 validation error."""
 
     resp = client.get("/api/images", params={"limit": 0})
     assert resp.status_code == 422
 
 
-def test_images_invalid_offset(client):
+@pytest.mark.asyncio
+async def test_images_invalid_offset(client):
     """offset must be >=0 – negative should raise 422."""
 
     resp = client.get("/api/images", params={"offset": -5})
@@ -29,20 +31,25 @@ def test_images_invalid_offset(client):
 # ---------------------------------------------------------------------------
 
 
-def test_generate_missing_prompt(client):
+@pytest.mark.asyncio
+async def test_generate_missing_prompt(client):
     """'prompt' is a required field; omitting it returns 422."""
 
     resp = client.post("/api/generate", json={"size": "1024x1024"})
     assert resp.status_code == 422
 
 
-def test_generate_internal_failure(client, mocker):
+@pytest.mark.asyncio
+async def test_generate_internal_failure(client, mocker):
     """If the OpenAI service returns no image data the route should reply 500."""
 
     # Patch generate_image_from_prompt to simulate OpenAI API returning nothing
+    async def mock_generate_failure(*args, **kwargs):
+        return (None, None)
+
     mocker.patch(
         "backend.app.services.openai_service.generate_image_from_prompt",
-        return_value=(None, None),
+        side_effect=mock_generate_failure,
     )
 
     resp = client.post(


### PR DESCRIPTION
Fixes %23 - Resolves the backend test failures that Jules couldn't fix

## Summary
- Fixed missing @pytest.mark.asyncio decorators on test functions using async fixtures
- Added explicit function scope to async fixtures for better isolation
- Fixed async mock patterns to properly handle coroutine behavior

## Root Cause
The backend tests were failing due to async/await inconsistencies where test functions used async fixtures but weren't properly marked as async themselves.

Generated with [Claude Code](https://claude.ai/code)