### PR TITLE
Switch to Responses API

### DIFF
--- a/backend/app/schemas/openai_params.py
+++ b/backend/app/schemas/openai_params.py
@@ -101,86 +101,10 @@ class EditImageRequest(BaseModel):
         description="Quality setting for gpt-image-1: 'auto', 'low', 'medium', or 'high'."
     )
     n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
+        default=1,
+        ge=1,
+        le=10,
         description="The number of edited images to generate. Must be between 1 and 10."
     )
 
 
-# DALL-E 3 PARAMETERS
-class DallE3BaseParams(BaseModel):
-    """Base parameters for the dall-e-3 model."""
-    model: Literal["dall-e-3"] = Field(default="dall-e-3", description="The OpenAI model to use for image generation.")
-    quality: Literal["standard", "hd"] = Field(
-        default="standard", 
-        description="The quality setting for the image generation. 'hd' creates more detailed images but costs more."
-    )
-    size: Literal["1024x1024", "1792x1024", "1024x1792"] = Field(
-        default="1024x1024", 
-        description="The size of the generated image. The default is 1024x1024."
-    )
-    style: Literal["vivid", "natural"] = Field(
-        default="vivid", 
-        description="The style of the generated image. 'vivid' is more intense colors, 'natural' is more realistic."
-    )
-
-
-class DallE3GenerationParams(DallE3BaseParams):
-    """Parameters for generating images with the dall-e-3 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=4000,
-        description="The text prompt that guides the image generation."
-    )
-    n: Literal[1] = Field(
-        default=1, 
-        description="The number of images to generate. DALL-E 3 only supports generating 1 image at a time."
-    )
-
-
-# DALL-E 2 PARAMETERS
-class DallE2BaseParams(BaseModel):
-    """Base parameters for the dall-e-2 model."""
-    model: Literal["dall-e-2"] = Field(default="dall-e-2", description="The OpenAI model to use for image generation.")
-    size: Literal["256x256", "512x512", "1024x1024"] = Field(
-        default="1024x1024", 
-        description="The size of the generated image. The default is 1024x1024."
-    )
-
-
-class DallE2GenerationParams(DallE2BaseParams):
-    """Parameters for generating images with the dall-e-2 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=1000,
-        description="The text prompt that guides the image generation."
-    )
-    n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
-        description="The number of images to generate. Must be between 1 and 10."
-    )
-
-
-class DallE2EditParams(DallE2BaseParams):
-    """Parameters for editing images with the dall-e-2 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=1000,
-        description="The text prompt that guides the image editing."
-    )
-    n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
-        description="The number of edited images to generate. Must be between 1 and 10."
-    )
-    # Image and Mask are handled separately as they're file uploads
-
-
-# Create an empty __init__.py file to make this a proper Python package 

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -34,22 +34,6 @@ def validate_model_n(n: int, info: ValidationInfo) -> int:
     
     return n
 
-def validate_model_style(style: str, info: ValidationInfo) -> str:
-    """Validate that the style is valid for the selected model."""
-    # Get the model value from the input data
-    model = info.data.get("model")
-    if not model or not style:
-        return style  # Missing data, let other validators handle it
-    
-    # Style is only supported for DALL-E 3
-    if model != "dall-e-3" and style:
-        raise ValueError(f"The 'style' parameter is only supported for the 'dall-e-3' model, not '{model}'.")
-    
-    # For DALL-E 3, style must be "vivid" or "natural"
-    if model == "dall-e-3" and style not in ["vivid", "natural"]:
-        raise ValueError(f"Invalid style '{style}' for model 'dall-e-3'. Valid values are: 'vivid', 'natural'.")
-    
-    return style
 
 def get_default_values_for_model(model: str) -> Dict[str, Any]:
     """Get default values for a specific model."""
@@ -57,17 +41,7 @@ def get_default_values_for_model(model: str) -> Dict[str, Any]:
         "gpt-image-1": {
             "quality": "auto",
             "size": "1024x1024",
-            "n": 1
+            "n": 1,
         },
-        "dall-e-3": {
-            "quality": "standard",
-            "size": "1024x1024",
-            "style": "vivid",
-            "n": 1
-        },
-        "dall-e-2": {
-            "size": "1024x1024",
-            "n": 1
-        }
     }
     return defaults.get(model, {}) 

--- a/backend/tests/test_edit_route.py
+++ b/backend/tests/test_edit_route.py
@@ -28,14 +28,14 @@ def mock_openai_edit(mocker):
     fake_png_b64 = base64.b64encode(b"EDITEDPNGDATA").decode()
 
     class _Item:
-        b64_json = fake_png_b64
-        revised_prompt = None
+        type = "image_generation_call"
+        result = fake_png_b64
 
-    async def _fake_edit(**kwargs):
-        return type("Resp", (), {"data": [_Item()]})
+    async def _fake_create(**kwargs):
+        return type("Resp", (), {"output": [_Item()]})
 
     mocker.patch(
-        "backend.app.services.openai_service.client.images.edit", _fake_edit
+        "backend.app.services.openai_service.client.responses.create", _fake_create
     )
 
 

--- a/backend/tests/test_generate_route.py
+++ b/backend/tests/test_generate_route.py
@@ -10,14 +10,14 @@ def mock_openai_generate(mocker):
     fake_png_b64 = base64.b64encode(b"PNGDATA").decode()
 
     class _Item:
-        b64_json = fake_png_b64
-        revised_prompt = None
+        type = "image_generation_call"
+        result = fake_png_b64
 
-    async def _fake_generate(**kwargs):
-        return type("Resp", (), {"data": [_Item()]})
+    async def _fake_create(**kwargs):
+        return type("Resp", (), {"output": [_Item()]})
 
     mocker.patch(
-        "backend.app.services.openai_service.client.images.generate", _fake_generate
+        "backend.app.services.openai_service.client.responses.create", _fake_create
     )
 
 


### PR DESCRIPTION
## Summary
- refactor OpenAI service to use `client.responses.create`
- drop all DALL‑E related code
- adjust schemas and validators for gpt-image-1 only
- update tests for new mocked API

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test --silent`