### PR TITLE
Add streaming image generation & editing

### DIFF
--- a/backend/app/routes/generation_routes.py
+++ b/backend/app/routes/generation_routes.py
@@ -1,5 +1,7 @@
 from fastapi import APIRouter, HTTPException, Body
+from fastapi.responses import StreamingResponse
 from typing import Optional
+import json
 import logging
 
 from ..services import openai_service
@@ -57,4 +59,34 @@ async def handle_generate_image(request: GenerateImageRequest = Body(...)):
     except Exception as e:
         # Catch any other unexpected errors during the process
         logger.error(f"Unexpected error handling image generation request: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="An unexpected error occurred during image generation.") 
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during image generation.")
+
+
+@router.post("/stream")
+async def stream_generate_image(request: GenerateImageRequest = Body(...)):
+    """Stream image generation chunks via SSE."""
+
+    async def event_generator():
+        accumulated = ""
+        params = {"model": "gpt-image-1", "size": request.size, "quality": request.quality, "n": request.n}
+
+        async for item in openai_service.generate_image_from_prompt_stream(
+            prompt=request.prompt,
+            size=request.size,
+            quality=request.quality,
+            n=request.n,
+        ):
+            if item.get("type") == "partial":
+                accumulated += item.get("data", "")
+                yield f"data: {json.dumps({'type': 'partial'})}\n\n"
+            elif item.get("type") == "complete":
+                accumulated += item.get("data", "")
+                saved = await openai_service.save_image_from_base64(
+                    [accumulated], request.prompt, None, params
+                )
+                meta = saved[0] if saved else None
+                payload = {"type": "complete", "metadata": meta.model_dump() if meta else None}
+                yield f"data: {json.dumps(payload)}\n\n"
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(event_generator(), media_type="text/event-stream")

--- a/backend/app/schemas/openai_params.py
+++ b/backend/app/schemas/openai_params.py
@@ -101,86 +101,10 @@ class EditImageRequest(BaseModel):
         description="Quality setting for gpt-image-1: 'auto', 'low', 'medium', or 'high'."
     )
     n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
+        default=1,
+        ge=1,
+        le=10,
         description="The number of edited images to generate. Must be between 1 and 10."
     )
 
 
-# DALL-E 3 PARAMETERS
-class DallE3BaseParams(BaseModel):
-    """Base parameters for the dall-e-3 model."""
-    model: Literal["dall-e-3"] = Field(default="dall-e-3", description="The OpenAI model to use for image generation.")
-    quality: Literal["standard", "hd"] = Field(
-        default="standard", 
-        description="The quality setting for the image generation. 'hd' creates more detailed images but costs more."
-    )
-    size: Literal["1024x1024", "1792x1024", "1024x1792"] = Field(
-        default="1024x1024", 
-        description="The size of the generated image. The default is 1024x1024."
-    )
-    style: Literal["vivid", "natural"] = Field(
-        default="vivid", 
-        description="The style of the generated image. 'vivid' is more intense colors, 'natural' is more realistic."
-    )
-
-
-class DallE3GenerationParams(DallE3BaseParams):
-    """Parameters for generating images with the dall-e-3 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=4000,
-        description="The text prompt that guides the image generation."
-    )
-    n: Literal[1] = Field(
-        default=1, 
-        description="The number of images to generate. DALL-E 3 only supports generating 1 image at a time."
-    )
-
-
-# DALL-E 2 PARAMETERS
-class DallE2BaseParams(BaseModel):
-    """Base parameters for the dall-e-2 model."""
-    model: Literal["dall-e-2"] = Field(default="dall-e-2", description="The OpenAI model to use for image generation.")
-    size: Literal["256x256", "512x512", "1024x1024"] = Field(
-        default="1024x1024", 
-        description="The size of the generated image. The default is 1024x1024."
-    )
-
-
-class DallE2GenerationParams(DallE2BaseParams):
-    """Parameters for generating images with the dall-e-2 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=1000,
-        description="The text prompt that guides the image generation."
-    )
-    n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
-        description="The number of images to generate. Must be between 1 and 10."
-    )
-
-
-class DallE2EditParams(DallE2BaseParams):
-    """Parameters for editing images with the dall-e-2 model."""
-    prompt: str = Field(
-        ..., 
-        min_length=1,
-        max_length=1000,
-        description="The text prompt that guides the image editing."
-    )
-    n: int = Field(
-        default=1, 
-        ge=1, 
-        le=10, 
-        description="The number of edited images to generate. Must be between 1 and 10."
-    )
-    # Image and Mask are handled separately as they're file uploads
-
-
-# Create an empty __init__.py file to make this a proper Python package 

--- a/backend/app/schemas/validators.py
+++ b/backend/app/schemas/validators.py
@@ -34,22 +34,6 @@ def validate_model_n(n: int, info: ValidationInfo) -> int:
     
     return n
 
-def validate_model_style(style: str, info: ValidationInfo) -> str:
-    """Validate that the style is valid for the selected model."""
-    # Get the model value from the input data
-    model = info.data.get("model")
-    if not model or not style:
-        return style  # Missing data, let other validators handle it
-    
-    # Style is only supported for DALL-E 3
-    if model != "dall-e-3" and style:
-        raise ValueError(f"The 'style' parameter is only supported for the 'dall-e-3' model, not '{model}'.")
-    
-    # For DALL-E 3, style must be "vivid" or "natural"
-    if model == "dall-e-3" and style not in ["vivid", "natural"]:
-        raise ValueError(f"Invalid style '{style}' for model 'dall-e-3'. Valid values are: 'vivid', 'natural'.")
-    
-    return style
 
 def get_default_values_for_model(model: str) -> Dict[str, Any]:
     """Get default values for a specific model."""
@@ -57,17 +41,7 @@ def get_default_values_for_model(model: str) -> Dict[str, Any]:
         "gpt-image-1": {
             "quality": "auto",
             "size": "1024x1024",
-            "n": 1
+            "n": 1,
         },
-        "dall-e-3": {
-            "quality": "standard",
-            "size": "1024x1024",
-            "style": "vivid",
-            "n": 1
-        },
-        "dall-e-2": {
-            "size": "1024x1024",
-            "n": 1
-        }
     }
     return defaults.get(model, {}) 

--- a/backend/app/services/openai_service.py
+++ b/backend/app/services/openai_service.py
@@ -1,13 +1,13 @@
 import logging
 import httpx
 import base64
-from openai import OpenAI, AsyncOpenAI, APIError, RateLimitError
+from openai import AsyncOpenAI, APIError, RateLimitError
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 import asyncio
 import aiofiles
 import uuid
 from datetime import datetime, timezone
-from typing import Optional, Tuple, List, Dict, Any
+from typing import Optional, Tuple, List, Dict, Any, AsyncIterable
 import os
 import io
 
@@ -39,74 +39,46 @@ retry_strategy = retry(
 @retry_strategy
 async def generate_image_from_prompt(
     prompt: str,
-    model: str = "gpt-image-1", # Default to gpt-image-1
-    size: str = "1024x1024", # Default size
-    quality: str = "auto", # Default quality for gpt-image-1
-    n: int = 1, # Default number of images
-    style: str = None # Only for dall-e-3
+    size: str = "1024x1024",
+    quality: str = "auto",
+    n: int = 1,
 ) -> tuple[Optional[List[str]], Optional[str]]:
-    """
-    Generates an image using OpenAI's API with retry logic.
+    """Generate an image using the Responses API.
 
-    Args:
-        prompt: The text prompt for image generation.
-        model: The model to use (e.g., "gpt-image-1", "dall-e-3", "dall-e-2").
-        size: The desired size of the image (model-specific).
-        quality: The quality setting (model-specific).
-        n: The number of images to generate (model-specific).
-        style: The style parameter (only for dall-e-3).
-
-    Returns:
-        A tuple containing:
-            - A list of base64 encoded image data (if successful).
-            - The revised prompt from OpenAI (if provided).
-        Returns (None, None) on failure after retries.
+    Only the ``gpt-image-1`` model is supported.
     """
-    logger.info(f"Requesting image generation for prompt: '{prompt}' with model={model}, size={size}, quality={quality}, n={n}")
+    logger.info(
+        f"Requesting image generation for prompt: '{prompt}' with size={size}, quality={quality}, n={n}"
+    )
     try:
-        # Build API parameters based on model
-        api_params = {
-            "model": model,
-            "prompt": prompt,
+        input_items = [
+            {"type": "message", "role": "user", "content": prompt}
+        ]
+        tool = {
+            "type": "image_generation",
+            "model": "gpt-image-1",
             "size": size,
-            "n": n,
+            "quality": quality,
         }
-        
-        # Add model-specific parameters
-        if model == "gpt-image-1" and quality:
-            api_params["quality"] = quality
-        elif model == "dall-e-3":
-            if quality:
-                api_params["quality"] = quality
-            if style:
-                api_params["style"] = style
-            # n is enforced as 1 for DALL-E 3
-            api_params["n"] = 1
-            
-        response = await client.images.generate(**api_params)
-        
-        # Extract base64 data from response (or URL for DALL-E 2/3 if b64_json wasn't specified)
-        image_data_list = []
-        for item in response.data:
-            if hasattr(item, 'b64_json') and item.b64_json:
-                image_data_list.append(item.b64_json)
-            elif hasattr(item, 'url') and item.url:
-                # For models that return URLs instead of base64 data by default
-                # We'll need to download the image
-                async with httpx.AsyncClient(timeout=30.0) as http_client:
-                    img_response = await http_client.get(item.url)
-                    if img_response.status_code == 200:
-                        # Convert to base64
-                        image_data = base64.b64encode(img_response.content).decode('utf-8')
-                        image_data_list.append(image_data)
-        
-        revised_prompt = response.data[0].revised_prompt if response.data and hasattr(response.data[0], 'revised_prompt') else None
-        
-        logger.info(f"Image(s) generated successfully. Number of images: {len(image_data_list)}")
-        if revised_prompt and revised_prompt != prompt:
-             logger.info(f"OpenAI revised prompt: '{revised_prompt}'")
-             
-        return image_data_list, revised_prompt
+
+        response = await client.responses.create(
+            model="gpt-image-1",
+            input=input_items,
+            tools=[tool],
+        )
+
+        image_data_list = [
+            output.result
+            for output in response.output
+            if getattr(output, "type", None) == "image_generation_call"
+            and getattr(output, "result", None)
+        ]
+
+        logger.info(
+            f"Image(s) generated successfully. Number of images: {len(image_data_list)}"
+        )
+
+        return image_data_list, None
 
     except RateLimitError as e:
         logger.warning(f"OpenAI rate limit hit during image generation: {e}. Retrying...")
@@ -129,19 +101,17 @@ async def generate_image_from_prompt(
 async def edit_image_from_prompt(
     prompt: str,
     image_bytes: bytes,
-    model: str = "gpt-image-1", # Default to gpt-image-1
     mask_bytes: Optional[bytes] = None,
-    size: str = "1024x1024", # gpt-image-1 supports various sizes
-    quality: str = "auto", # Default quality for gpt-image-1 (not used in API call)
-    n: int = 1 # Number of output images
-) -> Optional[List[str]]: # Returns list of base64 image data or None
+    size: str = "1024x1024",
+    quality: str = "auto",
+    n: int = 1,
+) -> Optional[List[str]]:
     """
     Edit an image using OpenAI's API with retry logic.
 
     Args:
         prompt: The text prompt describing the desired edit.
         image_bytes: The image data to edit (PNG format).
-        model: The model to use (e.g., "gpt-image-1", "dall-e-2").
         mask_bytes: Optional mask data (PNG format) indicating areas to edit.
         size: The desired size of the edited image.
         quality: The quality setting (kept for compatibility, not used in edit API).
@@ -151,40 +121,45 @@ async def edit_image_from_prompt(
         A list of base64 encoded edited image data, or None on failure after retries.
     """
     logger.info(
-        f"Requesting image edit for prompt: '{prompt}' with model={model}, size={size}, quality={quality}, n={n}")
+        f"Requesting image edit for prompt: '{prompt}' with size={size}, quality={quality}, n={n}")
     try:
-        # Prepare image parameter
-        image_param = ("image.png", image_bytes, "image/png")
-        
-        # Note: response_format parameter is not supported by images.edit API, only by images.generate
-        api_params = {
-            "model": model,
-            "image": image_param,
-            "prompt": prompt,
-            "size": size,
-            "n": n
-        }
-            
-        if mask_bytes:
-            mask_param = ("mask.png", mask_bytes, "image/png")
-            api_params["mask"] = mask_param
-            
-        response = await client.images.edit(**api_params)
+        input_items = [
+            {"type": "message", "role": "user", "content": prompt},
+            {
+                "type": "input_image",
+                "image_url": "data:image/png;base64," + base64.b64encode(image_bytes).decode(),
+                "detail": "auto",
+            },
+        ]
 
-        # Extract base64 data from response
-        image_data_list = []
-        for item in response.data:
-            if hasattr(item, 'b64_json') and item.b64_json:
-                image_data_list.append(item.b64_json)
-            elif hasattr(item, 'url') and item.url:
-                # For models that return URLs instead of base64 data by default
-                # We'll need to download the image
-                async with httpx.AsyncClient(timeout=30.0) as http_client:
-                    img_response = await http_client.get(item.url)
-                    if img_response.status_code == 200:
-                        # Convert to base64
-                        image_data = base64.b64encode(img_response.content).decode('utf-8')
-                        image_data_list.append(image_data)
+        if mask_bytes:
+            input_items.append(
+                {
+                    "type": "input_image",
+                    "image_url": "data:image/png;base64," + base64.b64encode(mask_bytes).decode(),
+                    "detail": "auto",
+                }
+            )
+
+        tool = {
+            "type": "image_generation",
+            "model": "gpt-image-1",
+            "size": size,
+            "quality": quality,
+        }
+
+        response = await client.responses.create(
+            model="gpt-image-1",
+            input=input_items,
+            tools=[tool],
+        )
+
+        image_data_list = [
+            output.result
+            for output in response.output
+            if getattr(output, "type", None) == "image_generation_call"
+            and getattr(output, "result", None)
+        ]
 
         logger.info(
             f"Image(s) edited successfully. Number of images: {len(image_data_list)}"
@@ -207,6 +182,98 @@ async def edit_image_from_prompt(
     except Exception as e:
         logger.error(f"Unexpected error during OpenAI image edit: {e}", exc_info=True)
         return None
+
+async def generate_image_from_prompt_stream(
+    prompt: str,
+    size: str = "1024x1024",
+    quality: str = "auto",
+    n: int = 1,
+) -> AsyncIterable[dict]:
+    """Stream image generation chunks from OpenAI.
+
+    Yields dictionaries describing partial or final chunks. Each yielded item
+    has at least a ``type`` field which is ``"partial"`` for incremental base64
+    data or ``"complete"`` containing the final base64 string.
+    """
+    input_items = [{"type": "message", "role": "user", "content": prompt}]
+    tool = {"type": "image_generation", "model": "gpt-image-1", "size": size, "quality": quality}
+
+    try:
+        stream = await client.responses.create(
+            model="gpt-image-1",
+            input=input_items,
+            tools=[tool],
+            stream=True,
+        )
+
+        async for chunk in stream:
+            for output in getattr(chunk, "output", []):
+                if getattr(output, "type", None) == "image_generation_chunk":
+                    delta = getattr(output, "delta", None)
+                    if delta and isinstance(delta, dict):
+                        data = delta.get("data")
+                        if data:
+                            yield {"type": "partial", "data": data}
+                elif getattr(output, "type", None) == "image_generation_call":
+                    result = getattr(output, "result", None)
+                    if result:
+                        yield {"type": "complete", "data": result}
+    except Exception as e:  # pragma: no cover - network errors handled upstream
+        logger.error("Streaming image generation failed: %s", e)
+        return
+
+
+async def edit_image_from_prompt_stream(
+    prompt: str,
+    image_bytes: bytes,
+    mask_bytes: Optional[bytes] = None,
+    size: str = "1024x1024",
+    quality: str = "auto",
+    n: int = 1,
+) -> AsyncIterable[dict]:
+    """Stream image edit chunks from OpenAI."""
+
+    input_items: List[dict] = [
+        {"type": "message", "role": "user", "content": prompt},
+        {
+            "type": "input_image",
+            "image_url": "data:image/png;base64," + base64.b64encode(image_bytes).decode(),
+            "detail": "auto",
+        },
+    ]
+    if mask_bytes:
+        input_items.append(
+            {
+                "type": "input_image",
+                "image_url": "data:image/png;base64," + base64.b64encode(mask_bytes).decode(),
+                "detail": "auto",
+            }
+        )
+
+    tool = {"type": "image_generation", "model": "gpt-image-1", "size": size, "quality": quality}
+
+    try:
+        stream = await client.responses.create(
+            model="gpt-image-1",
+            input=input_items,
+            tools=[tool],
+            stream=True,
+        )
+        async for chunk in stream:
+            for output in getattr(chunk, "output", []):
+                if getattr(output, "type", None) == "image_generation_chunk":
+                    delta = getattr(output, "delta", None)
+                    if delta and isinstance(delta, dict):
+                        data = delta.get("data")
+                        if data:
+                            yield {"type": "partial", "data": data}
+                elif getattr(output, "type", None) == "image_generation_call":
+                    result = getattr(output, "result", None)
+                    if result:
+                        yield {"type": "complete", "data": result}
+    except Exception as e:  # pragma: no cover
+        logger.error("Streaming image edit failed: %s", e)
+        return
 
 async def save_image_from_base64(
     image_data_list: List[str],

--- a/backend/tests/test_edit_route.py
+++ b/backend/tests/test_edit_route.py
@@ -28,14 +28,14 @@ def mock_openai_edit(mocker):
     fake_png_b64 = base64.b64encode(b"EDITEDPNGDATA").decode()
 
     class _Item:
-        b64_json = fake_png_b64
-        revised_prompt = None
+        type = "image_generation_call"
+        result = fake_png_b64
 
-    async def _fake_edit(**kwargs):
-        return type("Resp", (), {"data": [_Item()]})
+    async def _fake_create(**kwargs):
+        return type("Resp", (), {"output": [_Item()]})
 
     mocker.patch(
-        "backend.app.services.openai_service.client.images.edit", _fake_edit
+        "backend.app.services.openai_service.client.responses.create", _fake_create
     )
 
 

--- a/backend/tests/test_generate_route.py
+++ b/backend/tests/test_generate_route.py
@@ -10,14 +10,14 @@ def mock_openai_generate(mocker):
     fake_png_b64 = base64.b64encode(b"PNGDATA").decode()
 
     class _Item:
-        b64_json = fake_png_b64
-        revised_prompt = None
+        type = "image_generation_call"
+        result = fake_png_b64
 
-    async def _fake_generate(**kwargs):
-        return type("Resp", (), {"data": [_Item()]})
+    async def _fake_create(**kwargs):
+        return type("Resp", (), {"output": [_Item()]})
 
     mocker.patch(
-        "backend.app.services.openai_service.client.images.generate", _fake_generate
+        "backend.app.services.openai_service.client.responses.create", _fake_create
     )
 
 

--- a/frontend/src/__tests__/EditImageView.branches.test.tsx
+++ b/frontend/src/__tests__/EditImageView.branches.test.tsx
@@ -27,7 +27,7 @@ vi.mock('../components/ImageEditForm', () => ({
 
 const editMock = vi.fn();
 vi.mock('../api/imageEditing', () => ({
-  editImage: (...args: any[]) => editMock(...args),
+  editImageStream: (...args: any[]) => editMock(...args),
 }));
 
 import EditImageView from '../views/EditImageView';

--- a/frontend/src/__tests__/EditImageView.test.tsx
+++ b/frontend/src/__tests__/EditImageView.test.tsx
@@ -18,7 +18,7 @@ vi.mock('../components/ImageUploader', () => ({
 
 const editMock = vi.fn();
 vi.mock('../api/imageEditing', () => ({
-  editImage: (...args: any[]) => editMock(...args),
+  editImageStream: (...args: any[]) => editMock(...args),
 }));
 
 // Mock the getImageUrl function
@@ -63,13 +63,8 @@ describe('EditImageView', () => {
   });
 
   it('shows error when mask uploaded before original, then succeeds and displays result', async () => {
-    // Mock response with correct structure (ImageMetadata)
-    editMock.mockResolvedValueOnce({ 
-      id: 'test-image-id',
-      prompt: 'great prompt',
-      parameters: { size: '1024x1024', type: 'edit' },
-      filename: 'edited.png',
-      timestamp: '2023-01-01T00:00:00Z'
+    editMock.mockImplementationOnce(async (_p, _img, _mask, _s, cb) => {
+      cb({ type: 'complete', metadata: { id: 'test-image-id', filename: 'edited.png' } });
     });
     render(<EditImageView />);
 

--- a/frontend/src/__tests__/ImageGenerationForm.test.tsx
+++ b/frontend/src/__tests__/ImageGenerationForm.test.tsx
@@ -3,10 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import ImageGenerationForm from '../components/ImageGenerationForm';
 
-// Mock the generateImage API util so we can control its responses
+// Mock the streaming API util so we can control its responses
 const generateMock = vi.fn();
 vi.mock('../api/imageGeneration', () => ({
-  generateImage: (...args: any[]) => generateMock(...args),
+  generateImageStream: (...args: any[]) => generateMock(...args),
 }));
 
 describe('ImageGenerationForm', () => {
@@ -38,7 +38,9 @@ describe('ImageGenerationForm', () => {
   });
 
   it('successfully calls API and displays generated image', async () => {
-    generateMock.mockResolvedValueOnce({ filename: 'abc.png' });
+    generateMock.mockImplementationOnce(async (_req, cb) => {
+      cb({ type: 'complete', metadata: { filename: 'abc.png' } });
+    });
     render(<ImageGenerationForm />);
 
     fireEvent.change(screen.getByLabelText(/describe your image/i), { target: { value: 'A wonderfully descriptive prompt exceeding 10 chars' } });


### PR DESCRIPTION
## Summary
- stream image chunks from OpenAI via new service helpers
- expose `/generate/stream` and `/edit/stream` endpoints
- add frontend helpers `generateImageStream` and `editImageStream`
- update image generation form and edit view to use streaming API
- adjust unit tests for new streaming behaviour

## Testing
- `cd backend && pytest -q`
- `cd frontend && npm test --silent`
